### PR TITLE
fix: resolve crash after 25 pieces in Tetromino random shape generation

### DIFF
--- a/src/me/blog/justabullet/Tetromino.java
+++ b/src/me/blog/justabullet/Tetromino.java
@@ -12,6 +12,8 @@ public class Tetromino {
 		NO_BLOCK, Z_SHAPE, S_SHAPE, I_SHAPE, T_SHAPE, O_SHAPE, L_SHAPE, J_SHAPE
 	};
 
+	private static final Random random = new Random();
+
 	private Tetrominoes tetrominoes;
 	private int coords[][];				// current shape of a tetromino
 	private int tetrominoTable[][][];
@@ -45,8 +47,7 @@ public class Tetromino {
 	}
 
 	public void setRandomShape() {
-		Random r = new Random();
-		int x = Math.abs(r.nextInt()) % 7 + 1;
+		int x = random.nextInt(7) + 1;
 		setShape(Tetrominoes.values()[x]);
 	}
 


### PR DESCRIPTION
Fix critical ArrayIndexOutOfBoundsException in setRandomShape() method:
- Replace problematic Math.abs(r.nextInt()) % 7 with safe random.nextInt(7)
- Add static Random instance to avoid seeding issues
- Prevents crash caused by Math.abs(Integer.MIN_VALUE) returning negative value

Fixes #1

Generated with [Claude Code](https://claude.ai/code)